### PR TITLE
We shouldnt gitignore the schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ tmp
 *.swp
 
 db/*.db
-db/schema.rb


### PR DESCRIPTION
The schema should be checked in to be shared between team members
https://stackoverflow.com/questions/6520017/is-it-a-good-idea-to-put-db-schema-rb-to-gitignore-list
Thoughtbot removes it also https://github.com/thoughtbot/suspenders/commit/ff16ac2166451f980588c1b84d1b1c784f636f66